### PR TITLE
Parsing initiatorType as an integer

### DIFF
--- a/src/resourcetiming-decompression.js
+++ b/src/resourcetiming-decompression.js
@@ -116,7 +116,7 @@
             return {};
         }
 
-        var initiatorType = data[0];
+        var initiatorType = parseInt(data[0]);
         var timings = data.length > 1 ? data.substring(1).split(",") : [];
 
         // convert all timings from base36


### PR DESCRIPTION
Hi everyone

I ran into a subtle issue at decompression time: the original initiatortype

```
var initiatorType = data[0];
```

is actually a string, so when we try to compare this string with the initiatortypes reference map : 

```
ResourceTimingDecompression.INITIATOR_TYPES = {
        "other": 0,
        "img": 1,
        "link": 2,
        "script": 3,
        "css": 4,
        "xmlhttprequest": 5
    };
```

which are integers, then no initiatortype matches, as we use the === operator, so all resulting initiatortypes are equal to "other"

This PR parses the original value as an int, and keeps the === operator.
(You might as well keep the extraction code the same, and use the == operator, based on your javascript coding preferences)

Cheers
Fred
