### PR TITLE
Make hostname reversal configurable

### DIFF
--- a/src/resourcetiming-compression.js
+++ b/src/resourcetiming-compression.js
@@ -502,7 +502,7 @@
                 if (el) {
                     // src = IMG, IFRAME
                     // xlink:href = svg:IMAGE
-                    src = el.src || el.getAttribute("src") || el.getAttribute("xlink:href");
+                    src = el.currentSrc || el.src || el.getAttribute("src") || el.getAttribute("xlink:href");
 
                     // change src to be relative
                     a.href = src;
@@ -521,6 +521,29 @@
                                 Math.round(rect.top + y),
                                 Math.round(rect.left + x),
                             ];
+
+                            // If this is an image, it has a naturalHeight & naturalWidth
+                            // if these are different from its display height and width, we should report that
+                            // because it indicates scaling in HTML
+                            // If the image came from a srcset, then the naturalHeight/Width will be density corrected.
+                            // We get the actual physical dimensions by assigning the image to an uncorrected Image object.
+                            // This should load from in-memory cache, so there should be no extra load.
+                            var realImg = new Image();
+                            realImg.onload = function() {
+                                if (
+                                    (realImg.naturalHeight || realImg.naturalWidth)
+                                    &&
+                                    (
+                                        entries[src][0] !== realImg.naturalHeight
+                                        ||
+                                        entries[src][1] !== realImg.naturalWidth
+                                    )
+                                ) {
+                                    entries[src].push(realImg.naturalHeight, realImg.naturalWidth);
+                                }
+                            };
+                            realImg.src = el.src;
+
                         }
                     }
                 }

--- a/src/resourcetiming-compression.js
+++ b/src/resourcetiming-compression.js
@@ -526,7 +526,8 @@
                             // if these are different from its display height and width, we should report that
                             // because it indicates scaling in HTML
                             // If the image came from a srcset, then the naturalHeight/Width will be density corrected.
-                            // We get the actual physical dimensions by assigning the image to an uncorrected Image object.
+                            // We get the actual physical dimensions by assigning the image to an uncorrected Image
+                            // object.
                             // This should load from in-memory cache, so there should be no extra load.
                             var realImg = new Image();
                             realImg.onload = function() {

--- a/src/resourcetiming-compression.js
+++ b/src/resourcetiming-compression.js
@@ -36,6 +36,11 @@
     };
 
     /**
+     * Should hostnames in the compressed trie be reversed or not
+     */
+    ResourceTimingCompression.HOSTNAMES_REVERSED = true;
+
+    /**
      * Initiator type map
      */
     ResourceTimingCompression.INITIATOR_TYPES = {
@@ -824,7 +829,9 @@
             }
 
             url = this.trimUrl(e.name, this.trimUrls);
-            url = this.reverseHostname(url);
+            if (ResourceTimingCompression.HOSTNAMES_REVERSED) {
+                url = this.reverseHostname(url);
+            }
 
             // if this entry already exists, add a pipe as a separator
             if (results[url] !== undefined) {

--- a/src/resourcetiming-decompression.js
+++ b/src/resourcetiming-decompression.js
@@ -111,6 +111,11 @@
     };
 
     /**
+     * Are hostnames in the compressed trie reversed or not
+     */
+    ResourceTimingDecompression.HOSTNAMES_REVERSED = true;
+
+    /**
      * Initiator type map
      */
     ResourceTimingDecompression.INITIATOR_TYPES = {
@@ -545,7 +550,10 @@
             return {};
         }
 
-        url = ResourceTimingDecompression.reverseHostname(url);
+        if (ResourceTimingDecompression.HOSTNAMES_REVERSED) {
+            url = ResourceTimingDecompression.reverseHostname(url);
+        }
+
         var initiatorType = parseInt(data[0], 10);
         data = data.length > 1 ? data.split(SPECIAL_DATA_PREFIX) : [];
         var timings = data.length > 0 && data[0].length > 1 ? data[0].substring(1).split(",") : [];

--- a/src/resourcetiming-decompression.js
+++ b/src/resourcetiming-decompression.js
@@ -324,6 +324,11 @@
             return dimensionData;
         }
 
+        // If x is 0, and the last dimension, then it will be excluded, so initialize to 0
+        // If x & y are 0, and the last dimensions, then both will be excluded, so initialize to 0
+        dimensionData.y = 0;
+        dimensionData.x = 0;
+
         // Base 36 decode and assign to correct keys of dimensionData.
         for (i = 0; i < dimensions.length; i++) {
             if (dimensions[i] === "") {
@@ -331,6 +336,14 @@
             } else {
                 dimensionData[this.REV_DIMENSION_NAMES[i]] = parseInt(dimensions[i], 36);
             }
+        }
+
+        // If naturalHeight and naturalWidth are missing, then they are the same as height and width
+        if (!dimensionData.hasOwnProperty("naturalHeight")) {
+            dimensionData.naturalHeight = dimensionData.height;
+        }
+        if (!dimensionData.hasOwnProperty("naturalWidth")) {
+            dimensionData.naturalWidth = dimensionData.width;
         }
 
         return dimensionData;

--- a/test/test-resourcetiming-decompression.js
+++ b/test/test-resourcetiming-decompression.js
@@ -275,7 +275,11 @@
             it("Should a height, width of 1.", function() {
                 expect({
                     height: 1,
-                    width: 1
+                    width: 1,
+                    y: 0,
+                    x: 0,
+                    naturalHeight: 1,
+                    naturalWidth: 1
                 }).to.eql(ResourceTimingDecompression.decompressDimension("*01,1"));
             });
 
@@ -283,6 +287,8 @@
                 expect({
                     height: 1,
                     width: 1,
+                    naturalHeight: 1,
+                    naturalWidth: 1,
                     y: 1,
                     x: 1
                 }).to.eql(ResourceTimingDecompression.decompressDimension("*01,1,1,1"));
@@ -292,9 +298,22 @@
                 expect({
                     height: 1,
                     width: 1,
+                    naturalHeight: 1,
+                    naturalWidth: 1,
                     y: 0,
                     x: 1
                 }).to.eql(ResourceTimingDecompression.decompressDimension("*01,1,,1"));
+            });
+
+            it("Should find a height, width, x of 1 and y of 0, naturalHeight of 2 and naturalWidth of 4.", function() {
+                expect({
+                    height: 1,
+                    width: 1,
+                    naturalHeight: 2,
+                    naturalWidth: 4,
+                    y: 0,
+                    x: 1
+                }).to.eql(ResourceTimingDecompression.decompressDimension("*01,1,,1,2,4"));
             });
         });
 


### PR DESCRIPTION
This patch does three things:

1. Make hostname reversal configurable via `ResourceTimingDecompression.HOSTNAME_REVERSED`
2. Add `naturalHeight`/`Width` to `dimensionData`
3. Fix up optional fields in `dimensionData`