### PR TITLE
Add root-level compression and decompression exports

### DIFF
--- a/compression.js
+++ b/compression.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/resourcetiming-compression.js");

--- a/decompression.js
+++ b/decompression.js
@@ -1,0 +1,1 @@
+module.exports = require("./src/resourcetiming-decompression.js");


### PR DESCRIPTION
Exports root-level `compression` and `decompression` objects so one can use:

```
import ResourceTimingCompression from 'resourcetiming-compression/compression';
```

instead of:

```
import ResourceTimingCompression from 'resourcetiming-compression/src/resourcetiming-compression';
```