### PR TITLE
Fix workerstart extra trailing commas

### DIFF
--- a/src/resourcetiming-compression.js
+++ b/src/resourcetiming-compression.js
@@ -1117,7 +1117,9 @@
                 data += ResourceTimingCompression.SPECIAL_DATA_PREFIX
                     + ResourceTimingCompression.SPECIAL_DATA_SERVICE_WORKER_TYPE
                     + this.toBase36(workerStartOffset)
-                    + ((fetchStartOffset !== workerStartOffset) ? ("," + this.toBase36(fetchStartOffset)) : "");
+                    + ((fetchStartOffset !== workerStartOffset) ?
+                        ("," + this.toBase36(fetchStartOffset)).replace(/,+$/, "") : "");
+
             }
 
             finalUrl = url = this.trimUrl(e.name, this.trimUrls);

--- a/test/test-resourcetiming-compression.js
+++ b/test/test-resourcetiming-compression.js
@@ -853,6 +853,29 @@
                 });
             });
 
+            it("Should add trimmed workerStart offset (different than fetchStart)", function() {
+                var startTime = 1,
+                    workerStart = 1000,
+                    fetchStart = 1,
+                    responseEnd = 2000;
+
+                expect(ResourceTimingCompression.compressResourceTiming(null, [{
+                    name: "foo",
+                    initiatorType: "img",
+                    startTime: startTime,
+                    responseEnd: responseEnd,
+                    workerStart: workerStart,
+                    fetchStart: fetchStart
+                }], { lookup: {} })).to.eql({
+                    restiming: {
+                        "foo": "11,1jj"
+                            + "*6"
+                            + (workerStart - startTime).toString(36)
+                    },
+                    servertiming: {}
+                });
+            });
+
             it("Should compress http/1.1 nextHopProtocol data", function() {
                 expect(ResourceTimingCompression.compressResourceTiming(null, [{
                     name: "foo",


### PR DESCRIPTION
Fixes bug when fetchStart matches startTime, it adds a trailing comma to the workerStart